### PR TITLE
UX-844 fix: displayName added to FormGroup

### DIFF
--- a/src/FormGroup.tsx
+++ b/src/FormGroup.tsx
@@ -194,3 +194,5 @@ export default function FormGroup({
     </ConditionalWrapper>
   );
 }
+
+FormGroup.displayName = 'FormGroup';


### PR DESCRIPTION
missing displayName causes errors in Portal tests