### PR TITLE
UX-924 fix: disable submit button when pristine

### DIFF
--- a/src/FormCard.test.tsx
+++ b/src/FormCard.test.tsx
@@ -173,7 +173,7 @@ describe('FormCard', () => {
       );
       expect(getByText('Success')).toBeInTheDocument();
       expect(getByText('Reset').closest('button')).toBeDisabled();
-      expect(getByText('Submit')).toBeInTheDocument();
+      expect(getByText('Submit').closest('button')).toBeDisabled();
     });
 
     it('shows submit error if there is one', () => {

--- a/src/FormCard.tsx
+++ b/src/FormCard.tsx
@@ -163,7 +163,12 @@ export const defaultFooterRenderProp = ({
       <Button type="reset" disabled={!dirty || isSubmitting} onClick={onReset}>
         {resetContent}
       </Button>
-      <Button type="submit" loading={isSubmitting} primary>
+      <Button
+        type="submit"
+        disabled={!dirty || isSubmitting}
+        loading={isSubmitting}
+        primary
+      >
         {submitContent}
       </Button>
     </ButtonGroup>


### PR DESCRIPTION
Disable form card save button unless form is dirty.