### PR TITLE
fix: adding value prop to FieldNumber

### DIFF
--- a/src/FieldNumber.test.tsx
+++ b/src/FieldNumber.test.tsx
@@ -23,6 +23,7 @@ describe('(Component) FieldNumber', () => {
       size: 'medium',
       suffix: 'someSuffix',
       width: 100,
+      value: 123,
       ...p
     };
     return renderRTL(
@@ -40,10 +41,11 @@ describe('(Component) FieldNumber', () => {
   beforeEach(jest.clearAllMocks);
 
   it('passes props as expected', () => {
-    const { getByPlaceholderText, getByLabelText } = render();
+    const { getByPlaceholderText, getByLabelText, container } = render();
 
     expect(getByLabelText('barlabel')).toBeInTheDocument();
     expect(getByPlaceholderText('barph')).toBeInTheDocument();
+    expect(container.querySelector('input')?.value).toBe("123");
   });
 
   it('will call handlers on events', () => {

--- a/src/FieldNumber.tsx
+++ b/src/FieldNumber.tsx
@@ -46,6 +46,7 @@ export const generateFieldNumberRenderProp =
     size,
     suffix,
     width,
+    value,
   }: FieldNumberAdapterOptions) =>
   /**
    * Disabling the line below because of an existing bug with eslint
@@ -81,6 +82,7 @@ export const generateFieldNumberRenderProp =
         suffix={suffix}
         validationText={errors[name]}
         width={width}
+        value={value}
       />
     );
 
@@ -109,6 +111,7 @@ const FieldNumberAdapter = ({
   suffix,
   type,
   width,
+  value,
 }: FieldNumberAdapterOptions): JSX.Element => (
   <Field name={name} type={type}>
     {generateFieldNumberRenderProp({
@@ -129,6 +132,7 @@ const FieldNumberAdapter = ({
       size,
       suffix,
       width,
+      value,
     })}
   </Field>
 );
@@ -211,6 +215,10 @@ interface FieldNumberAdapterOptions extends InputOptions {
    * For responsive behavior, pass an array with length up to 4, with one of the above values.
    */
   width?: DimensionType;
+  /**
+   * The field value
+   */
+  value?: number;
 }
 
 // Appending display name attribute to conform to the desired name


### PR DESCRIPTION
Why is this change being made:
To allow a value to be passed to underlying component.

What is being change:
Adding 'value' as a prop.

Does this change break anything:
No

Fixes: #17 